### PR TITLE
Added a configurable CPU percentage alert threshold.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ Default settings:
 
 * `drive` is `/`. If the value is incorrect or not found, / will be monitored by default.
 * `small_interval` is `1` second. Represents the refresh_rate of the cpu and network workers.
+* `cpu_percent_usage_alert_threshold` is `90` (percent). When this CPU utilization percentage is surpassed the monitor will send out an alert.
 
 To modify the config values you can use Keymetrics dashboard or the following commands:
 
 ```bash
 pm2 set pm2-server-monit:drive /
 pm2 set pm2-server-monit:small_interval 10
+pm2 set pm2-server-monit:cpu_percent_usage_alert_threshold 90
 ```
 
 :warning: If this module uses too much CPU, set the `small_interval` value to 10 or more.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PM2 module to automatically monitor vital signs of your server :
 ```bash
 $ npm install pm2 -g
 
-$ pm2 install pm2-server-monit
+$ pm2 install thirdiron/pm2-server-monit
 ```
 
 ## Configuration
@@ -32,14 +32,15 @@ Default settings:
 
 * `drive` is `/`. If the value is incorrect or not found, / will be monitored by default.
 * `small_interval` is `1` second. Represents the refresh_rate of the cpu and network workers.
-* `cpu_percent_usage_alert_threshold` is `90` (percent). When this CPU utilization percentage is surpassed the monitor will send out an alert.
+* `cpu_percent_usage_alert_threshold` is `90` (percent). When this CPU utilization percentage is consistently surpassed the monitor will send out an alert.
+  * Note: Setting this to `100` will effectively disable high CPU utilization alerts.
 
 To modify the config values you can use Keymetrics dashboard or the following commands:
 
 ```bash
-pm2 set pm2-server-monit:drive /
-pm2 set pm2-server-monit:small_interval 10
-pm2 set pm2-server-monit:cpu_percent_usage_alert_threshold 90
+pm2 set thirdiron/pm2-server-monit:drive /
+pm2 set thirdiron/pm2-server-monit:small_interval 10
+pm2 set thirdiron/pm2-server-monit:cpu_percent_usage_alert_threshold 90
 ```
 
 :warning: If this module uses too much CPU, set the `small_interval` value to 10 or more.
@@ -51,13 +52,13 @@ If you have ❌ in some categories, your OS configuration is not supported for t
 ## Uninstall
 
 ```bash
-$ pm2 uninstall pm2-server-monit
+$ pm2 uninstall thirdiron/pm2-server-monit
 ```
 
 ## Update to latest version
 
 ```bash
-$ pm2 module:update pm2-server-monit
+$ pm2 module:update thirdiron/pm2-server-monit
 ```
 
 # License

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -38,13 +38,13 @@ function refreshMetrics(interval) {
   }, 100);
 }
 
-function initMetrics() {
+function initMetrics(percentageAlertThreshold) {
   metrics.cpuResult = probe.metric({
     name: 'CPU usage',
     value: 'N/A',
     alert : {
       mode : 'threshold-avg',
-      value : 90,
+      value : percentageAlertThreshold,
       interval : 100,
       cmp : '>'
     }
@@ -52,7 +52,7 @@ function initMetrics() {
 }
 
 function init(conf) {
-  initMetrics();
+  initMetrics(conf.cpu_percent_usage_alert_threshold);
   refreshMetrics(conf.small_interval);
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "config": {
     "drive": "/",
-    "small_interval": "1"
+    "small_interval": "1",
+    "cpu_percent_usage_alert_threshold": "90"
   },
   "scripts": {
     "start": "node app",


### PR DESCRIPTION
In some situations, CPU usage thresholds other than 90% warrant concern. For example:

- If this is a production web server with a heavy focus on real time performance, a threshold lower than 90% may be desirable.
- If this is a background jobs server with a single core, a sustained 100% load may be the only one of any concern.

Since alerts are not configurable by server component in the library (currently), I'm adding a configuration for the threshold so the user can choose when to be notified.